### PR TITLE
Add command to show poll time

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,6 +40,7 @@ def main():
     application.add_handler(CommandHandler("stop_poll", handlers.stop_poll))
     application.add_handler(CommandHandler("stats", handlers.stats_command))
     application.add_handler(CommandHandler("set_poll_time", handlers.set_poll_time_command))
+    application.add_handler(CommandHandler("get_poll_time", handlers.get_poll_time_command))
     
     # Steam related commands
     application.add_handler(CommandHandler("link_steam", handlers.link_steam_command))


### PR DESCRIPTION
## Summary
- display the stored poll time via `/get_poll_time`
- register the command and show in /start message

## Testing
- `python test_db.py`
- `python -m py_compile handlers.py app.py scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_6850763068548329aab62d702c43fdbc