### PR TITLE
Update Steam status check to run hourly

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -27,10 +27,10 @@ async def setup_jobs(job_queue, send_poll_func, steam_api_key):
         # Set up custom poll times for each chat
         await setup_custom_poll_times(job_queue, send_poll_func, chat_times)
     
-    # Set up Steam status checker - run every 5 minutes
+    # Set up Steam status checker - run hourly
     steam_check_job = job_queue.run_repeating(
         lambda ctx: steam.check_steam_status(ctx, steam_api_key, send_poll_func),
-        interval=5*60,  # Check every 5 minutes
+        interval=60*60,  # Check every hour
         first=0  # Start immediately
     )
     


### PR DESCRIPTION
## Summary
- adjust Steam status job from every 5 minutes to hourly

## Testing
- `python -m py_compile scheduler.py steam.py poll_state.py db.py handlers.py who_is_online.py web_server.py app.py`
- `python test_db.py`

------
https://chatgpt.com/codex/tasks/task_e_6851a46aec688329b17e6164a2c218ae