### PR TITLE
Improve message handler resilience

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,15 @@ import os
 import asyncio
 from dotenv import load_dotenv
 
-from telegram.ext import ApplicationBuilder, CommandHandler, PollAnswerHandler, CallbackQueryHandler, ConversationHandler
+from telegram.ext import (
+    ApplicationBuilder,
+    CommandHandler,
+    MessageHandler,
+    filters,
+    PollAnswerHandler,
+    CallbackQueryHandler,
+    ConversationHandler,
+)
 
 import db
 import handlers
@@ -46,6 +54,9 @@ def main():
     application.add_handler(CommandHandler("link_steam", handlers.link_steam_command))
     application.add_handler(CommandHandler("unlink_steam", handlers.unlink_steam_command))
     application.add_handler(CommandHandler("who_is_playing", handlers.who_is_playing_command))
+
+    # Text messages
+    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.handle_message))
     
     # Callback query handlers
     application.add_handler(CallbackQueryHandler(handlers.handle_unlink_steam_confirm, pattern="^unlink_confirm:"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ apscheduler
 python-dotenv
 pytz
 aiohttp
+httpx


### PR DESCRIPTION
## Summary
- create a `safe_reply` helper to send messages without crashing
- fetch answers from a remote service in `handle_message`
- add text message handler to app
- include httpx dependency

## Testing
- `python test_db.py`

------
https://chatgpt.com/codex/tasks/task_e_6884ca0615688329bdf35e54b13cc003